### PR TITLE
Added RECAPTCHAV3_HIDDEN option to hide badge on pages without recapt…

### DIFF
--- a/src/RecaptchaV3.php
+++ b/src/RecaptchaV3.php
@@ -36,15 +36,22 @@ class RecaptchaV3
     protected $request;
 
     /**
+     * @var bool
+     */
+    protected $hidden;
+
+    /**
      * RecaptchaV3 constructor.
      *
      * @param $secret
      * @param $sitekey
+     * @param $hidden
      */
     public function __construct(Repository $config, Client $client, Request $request)
     {
         $this->secret = $config['recaptchav3']['secret'];
         $this->sitekey = $config['recaptchav3']['sitekey'];
+        $this->hidden = $config['recaptchav3']['hidden'];
         $this->http = $client;
         $this->request = $request;
     }
@@ -98,7 +105,9 @@ class RecaptchaV3
      */
     public function initJs()
     {
-        return '<script src="https://www.google.com/recaptcha/api.js?render=' . $this->sitekey . '"></script>';
+        $html = '<script src="https://www.google.com/recaptcha/api.js?render=' . $this->sitekey . '"></script>';
+        if($this->hidden) $html .='<style>.grecaptcha-badge { visibility:hidden; }</style>';
+        return $html;
     }
 
 
@@ -109,6 +118,7 @@ class RecaptchaV3
     {
         $fieldId = uniqid($name . '-', false);
         $html = '<input type="hidden" name="' . $name . '" id="' . $fieldId . '">';
+        if($this->hidden) $html .= "<style>.grecaptcha-badge { visibility: visible !important; }</style>";
         $html .= "<script>
   grecaptcha.ready(function() {
       grecaptcha.execute('" . $this->sitekey . "', {action: '" . $action . "'}).then(function(token) {

--- a/src/config/recaptchav3.php
+++ b/src/config/recaptchav3.php
@@ -1,5 +1,6 @@
 <?php
 return [
     'sitekey' => env('RECAPTCHAV3_SITEKEY', ''),
-    'secret' => env('RECAPTCHAV3_SECRET', '')
+    'secret' => env('RECAPTCHAV3_SECRET', ''),
+	'hidden' => env('RECAPTCHAV3_HIDDEN', false)
 ];


### PR DESCRIPTION
I recently implemented Google recaptcha v3, I run the javascript code on each page for for the proper functioning, but I don't want the banner to appear on all pages, only in that where it is in use.

I have hidden the banner according to the google guidelines that appear here.
https://developers.google.com/recaptcha/docs/faq

works perffect.

The feature is disabled by default, it can be switched by editing RECAPTCHAV3_HIDDEN key (true/false) in the .env file