### PR TITLE
feat: wrap grecaptcha ready in content loaded listener

### DIFF
--- a/src/RecaptchaV3.php
+++ b/src/RecaptchaV3.php
@@ -119,12 +119,14 @@ class RecaptchaV3
         $fieldId = uniqid($name . '-', false);
         $html = '<input type="hidden" name="' . $name . '" id="' . $fieldId . '">';
         $html .= "<script>
-  grecaptcha.ready(function() {
-      grecaptcha.execute('" . $this->sitekey . "', {action: '" . $action . "'}).then(function(token) {
-         document.getElementById('" . $fieldId . "').value = token;
-      });
-  });
-  </script>";
+            document.addEventListener('DOMContentLoaded', (event) => {
+                grecaptcha.ready(function() {
+                    grecaptcha.execute('" . $this->sitekey . "', {action: '" . $action . "'}).then(function(token) {
+                        document.getElementById('" . $fieldId . "').value = token;
+                    });
+                });
+            });
+        </script>";
         return $html;
     }
 


### PR DESCRIPTION
Allows initJS to be called at end of doc to prevent render blocking, which increases load speed for better Google scores