### PR TITLE
Compatibility with Laravel Blade and Vue root element

### DIFF
--- a/src/RecaptchaV3.php
+++ b/src/RecaptchaV3.php
@@ -118,7 +118,7 @@ class RecaptchaV3
     {
         $fieldId = uniqid($name . '-', false);
         $html = '<input type="hidden" name="' . $name . '" id="' . $fieldId . '">';
-        $html .= "<script>
+        $html .= "<script type='application/javascript'>
   grecaptcha.ready(function() {
       grecaptcha.execute('" . $this->sitekey . "', {action: '" . $action . "'}).then(function(token) {
          document.getElementById('" . $fieldId . "').value = token;


### PR DESCRIPTION
When using `RecaptchaV3::field(...)` on a blade page inside a Vue root element, Vue compiler fails because of the inline script.
To prevent that, we can use `v-pre` directive but it only works for scripts with type attribute of `application/javascript`.